### PR TITLE
Smaller output and position prediction

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,14 +4,13 @@
 // #define WIN32_LEAN_AND_MEAN
 // #endif
 
-#include <openvr.h> 
+
 #include <string>
 #include <iostream>
-#include <fstream>
+
+#include "openvr.h"
 #include "server.hpp"
 #include "message.hpp"
-#include <exception>
-#include <algorithm>
 
 
 int main(int argc, char** argv) {
@@ -39,8 +38,6 @@ int main(int argc, char** argv) {
 	
     while(true) {
 		Message message;
-		vr::VREvent_t event;
-		vr::TrackedDevicePose_t* pose;
 		vr::VRControllerState_t c_state;
 		int iter_c = 0;
 		int iter_t = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -42,8 +42,18 @@ int main(int argc, char** argv) {
 		int iter_c = 0;
 		int iter_t = 0;
 
+		// https://github.com/ValveSoftware/openvr/wiki/IVRSystem::GetDeviceToAbsoluteTrackingPose
+		float fSecondsSinceLastVsync;
+		vrsys->GetTimeSinceLastVsync(&fSecondsSinceLastVsync, NULL);
+
+		float fDisplayFrequency = vrsys->GetFloatTrackedDeviceProperty(vr::k_unTrackedDeviceIndex_Hmd, vr::Prop_DisplayFrequency_Float);
+		float fFrameDuration = 1.f / fDisplayFrequency;
+		float fVsyncToPhotons = vrsys->GetFloatTrackedDeviceProperty(vr::k_unTrackedDeviceIndex_Hmd, vr::Prop_SecondsFromVsyncToPhotons_Float);
+
+		float fPredictedSecondsFromNow = fFrameDuration - fSecondsSinceLastVsync + fVsyncToPhotons;
+
 		//set coordinates
-		vrsys->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseStanding, 0.0, devices, vr::k_unMaxTrackedDeviceCount);
+		vrsys->GetDeviceToAbsoluteTrackingPose(vr::TrackingUniverseStanding, fPredictedSecondsFromNow, devices, vr::k_unMaxTrackedDeviceCount);
 		for (int i = 0; i < vr::k_unMaxTrackedDeviceCount; ++i) {
 			if (devices[i].bPoseIsValid && devices[i].bDeviceIsConnected) {
 				if (vr::VRSystem()->GetTrackedDeviceClass(i) == vr::TrackedDeviceClass_HMD) {

--- a/message.hpp
+++ b/message.hpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #ifndef VRSYS_HMD_MESSAGE
 #define VRSYS_HMD_MESSAGE
 
@@ -70,7 +68,7 @@ struct Message {
 		hmd[10] = 1;
 		hmd[15] = 1;
 
-		for (int i; i < 4; ++i) {
+		for (int i = 0; i < 4; ++i) {
 			controller[i] = Controller();
 		}
 		for (int j  = 0; j < 2; ++j)

--- a/server.hpp
+++ b/server.hpp
@@ -1,20 +1,24 @@
-#pragma once
-
 #ifndef VRSYS_HMD_SERVER
 #define VRSYS_HMD_SERVER
 
-#include <zmq.hpp>
 #include <array>
+#include <chrono>
+
 #include "message.hpp"
+#include "zmq.hpp"
+
+typedef std::chrono::high_resolution_clock Clock;
+typedef std::chrono::milliseconds milliseconds;
 
 struct Server {
 	Server(std::string address)
 	  : m_ctx(1)
 	  , m_socket(m_ctx, ZMQ_PUB)
+	  , m_packets_since_last_print(0)
+	  , m_last_print_time(Clock::now())
 	{
 		uint32_t hwm = 1;
 		m_socket.setsockopt(ZMQ_SNDHWM, &hwm, sizeof(hwm));
-
 		m_socket.bind(address.c_str());
 	}
 
@@ -24,11 +28,24 @@ struct Server {
 		zmq::message_t message(len);
 		memcpy(message.data(), msg, len);
 		m_socket.send(message);
-		std::cout << ".";
+		++m_packets_since_last_print;
+
+		Clock::time_point now = Clock::now();
+		__int64 elapsed_ms(std::chrono::duration_cast<milliseconds>(now - m_last_print_time).count());
+
+		if (elapsed_ms > 1000) {
+			std::cout << "Sent " << m_packets_since_last_print << " packets in a second." << std::endl;
+			m_packets_since_last_print = 0;
+			m_last_print_time = Clock::now();
+		}
+
 		return 1;
 	}
+
 	zmq::context_t m_ctx;
 	zmq::socket_t m_socket;
+	int m_packets_since_last_print;
+	Clock::time_point m_last_print_time;
 };
 
 #endif


### PR DESCRIPTION
Make output of HMD-Server less verbose for speed reasons.
Implement position prediction mechanism according to OpenVR documentation for smoother position updates.